### PR TITLE
Fix checking skiplist when processing fields subject to field_order.

### DIFF
--- a/lib/blackboxprotobuf/lib/types/length_delim.py
+++ b/lib/blackboxprotobuf/lib/types/length_delim.py
@@ -126,10 +126,10 @@ def encode_message(data, config, typedef, path=None, field_order=None):
                 # fields is that it's a default decoding which won't be a packed
                 try:
                     new_output = _encode_message_field(
-                        config, typedef, path, field_number, value, selected_index=index
+                        config, typedef, path, field_number, value,
+                        selected_index=index, skiplist=skiplist
                     )
                     output += new_output
-                    skiplist.add((field_number, index))
                 except EncoderException as exc:
                     logging.warn(
                         "Error encoding priority field: %s %s %r %r",
@@ -138,6 +138,8 @@ def encode_message(data, config, typedef, path=None, field_order=None):
                         path,
                         exc,
                     )
+                finally:
+                    skiplist.add((field_number, index))
 
     for field_number, value in data.items():
         new_output = _encode_message_field(


### PR DESCRIPTION
I found I was getting some erroneous duplicated fields when decoding and re-encoding a protobuf, even without making any changes to the content. I discovered this was because when processing fields with a field_order, the skiplist was not being used. Also, when a field fails to encode, I believe we want to add it to the skiplist. This PR addresses both those concerns.